### PR TITLE
Added try/except to GreydenSkillsLibrary to prevent error

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
 	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 	"version": "0.2.0",
 	"configurations": [
+
 		{
 			"name": "Gyro",
 			"type": "ev3devBrowser",
@@ -23,6 +24,13 @@
 			"type": "ev3devBrowser",
 			"request": "launch",
 			"program": "/home/robot/${workspaceRootFolderName}/uber.py",
+			"interactiveTerminal": false
+		},
+		{
+			"name": "GreydenSkills",
+			"type": "ev3devBrowser",
+			"request": "launch",
+			"program": "/home/robot/${workspaceRootFolderName}/GreydenSkillsLibrary.py",
 			"interactiveTerminal": false
 		}
 	

--- a/GreydenSkillsLibrary.py
+++ b/GreydenSkillsLibrary.py
@@ -12,8 +12,24 @@ from pybricks.media.ev3dev import SoundFile, ImageFile
 class Greyden_Skills:
 	def __init__(self, robot):
 		self.robot = robot
+		try:
+			self.gyro = GyroSensor(Port.S2, Direction.CLOCKWISE)
+		except:
+			self.gyro = None
+			print("No Gyro Sensor plugged into Port 2. Cannot run Greyden's Skills. :-(")
+			print()
+	
+	def gyro_angle(self):
+		if self.gyro is None:
+			return float("nan")
+		else:
+			return self.gyro.angle()
 
 	def tell_me_about_your_skills(self):
 		print("SKILLS - I can read the Gyro Sensor!")
-		print("SKILLS - I am able to show you the Gyro angle, see",self.robot.gyro.angle())
+		print("SKILLS - I am able to show you the Gyro angle, see",self.gyro_angle())
 		print()
+
+if __name__ == '__main__':
+	GreydenSkillBot = Greyden_Skills(None)
+	GreydenSkillBot.tell_me_about_your_skills()


### PR DESCRIPTION
I fixed the code so that when you don't have a gyro sensor plugged in, it doesn't create an error. I used a try/except statement to help with this. The error would look like this:

```
A sensor or motor is not connected to the specified port:
--> Check the cables to each motor and sensor.
--> Check the port settings in your script.
--> Check the line in your script that matches
    the line number given in the 'Traceback' above.
```