### PR TITLE
made gyro drive heading useful

### DIFF
--- a/CrabRobotLibrary.py
+++ b/CrabRobotLibrary.py
@@ -94,7 +94,8 @@ class Robot:
 		if side == "left":
 			sensor = self.left_color
 		while sensor.reflection() < 50:
-			correction = self.gyro.angle() * -10
+			adjusted_angle =  self.gyro.angle() - heading
+			correction = adjusted_angle * -10
 			self.robot.drive(speed, correction)
 		self.robot.stop()
 
@@ -103,7 +104,8 @@ class Robot:
 		self.robot.reset()
 		actual_distance = 0
 		while actual_distance > distance:
-			correction = self.gyro.angle() * -10
+			adjusted_angle =  self.gyro.angle() - heading
+			correction = adjusted_angle * -10
 			self.robot.drive(speed, correction)
 			wait(10)
 			actual_distance = self.robot.distance()

--- a/CrabRobotLibrary.py
+++ b/CrabRobotLibrary.py
@@ -80,7 +80,8 @@ class Robot:
 		self.robot.reset()
 		actual_distance = 0
 		while actual_distance < distance:
-			correction = self.gyro.angle() * -10
+			adjusted_angle =  self.gyro.angle() - heading
+			correction = adjusted_angle * -10
 			self.robot.drive(speed, correction)
 			wait(10)
 			actual_distance = self.robot.distance()

--- a/run_cheese.py
+++ b/run_cheese.py
@@ -15,8 +15,8 @@ def run_table(crabot):
 	# todo: lower the front medium motor so its down
 
 	crabot.front_activate(100, 65, Direction.COUNTERCLOCKWISE)
-	crabot.gyro_drive(300, 0, 1300)
-	crabot.gyro_drive(40, 0, 365)
+	crabot.gyro_drive(300, 0, 1280)
+	crabot.gyro_drive(40, 0, 385)
 	crabot.bw_gyro_drive(-150, 0, -15)
 	crabot.gyro_turn(-90, -90)
 	crabot.gyro_reset()
@@ -27,15 +27,15 @@ def run_table(crabot):
 	crabot.gyro_reset()
 	crabot.gyro_drive(300, -0, 1000)
 	crabot.gyro_turn(35, Direction.CLOCKWISE)
-	crabot.gyro_reset()
-	crabot.gyro_drive(90, 0, 150)
+	crabot.gyro_drive(90, 35, 150)
 	wait(1000)
+	# flips up boccia ball
 	crabot.front_activate(100, 50, Direction.COUNTERCLOCKWISE)
 	crabot.bw_gyro_drive(-40, 0, -100)
 	crabot.gyro_turn(-85, Direction.COUNTERCLOCKWISE) 
-	crabot.gyro_reset()
 	crabot.front_activate(100, 50, Direction.CLOCKWISE)
-	crabot.gyro_drive(250, 0, 600)
+	crabot.gyro_drive(250, -50, 600)
+	crabot.gyro_reset()
 	while True:
 		crabot.gyro_drive(90, 0, 100)
 		crabot.bw_gyro_drive(-90, 0, -100)

--- a/run_treadmill.py
+++ b/run_treadmill.py
@@ -14,10 +14,8 @@ def run_treadmill(crabot):
 	crabot.gyro_drive(400, 0, 1850)
 	crabot.gyro_drive_until_white(200, 0, "left")
 	crabot.gyro_turn(20, Direction.CLOCKWISE)
-	crabot.gyro_reset()
 	crabot.gyro_drive(100, 20, 300)
 	crabot.gyro_turn(-20, Direction.COUNTERCLOCKWISE)
-	crabot.gyro_reset()
 	crabot.gyro_drive(200, 0, 200)
 
 if __name__ == '__main__':


### PR DESCRIPTION
**BREAKING CHANGE**

I fixed a bug that made the gyro drive heading useless. This makes it identical to last year's MyBlock. However, this may break existing programs if they aren't using a 0 for the heading when they use the `gyro_drive()` function.