### PR TITLE
Edited entry to the treadmill in run_treadmill.

### DIFF
--- a/run_treadmill.py
+++ b/run_treadmill.py
@@ -20,9 +20,9 @@ def go_there(crabot):
 def treadmill(crabot):
 	print("time to get those steps in!")
 	crabot.gyro_reset()
-	crabot.gyro_drive(100, 0, 250)
+	crabot.gyro_drive(100, 0, 230)
 	crabot.gyro_turn(85, Direction.CLOCKWISE)
-	crabot.gyro_drive(500, 90, 400)
+	crabot.gyro_drive(500, 90, 370)
 	while crabot.gyro.angle() > 90:
 		crabot.left_wheel.run(-100)
 	crabot.left_wheel.stop()


### PR DESCRIPTION
Movement from the wall (North) reduced by 2 centimeters to better align with the treadmill. Motion to the treadmill (East) reduced by 3 centimeters. Before making this adjustment, my robot would consistently be on the very edge of the rollers and it consistently overshot the treadmill to the East wall. Video available to explain my issue.